### PR TITLE
Fix path to executable in Windows launcher

### DIFF
--- a/osm_racing_game.cmd
+++ b/osm_racing_game.cmd
@@ -1,6 +1,6 @@
 cd /D "%~dp0" || exit /b
 
-GMRelease\render_scene_file.exe ^
+GVSRelease\render_scene_file.exe ^
     data ^
     data\levels\main\main.scn.json ^
     --app_reldir osm_rally ^


### PR DESCRIPTION
This fixes the `The system cannot find the path specified.` error when trying to launch the [latest release](https://github.com/gre-42/MGame/releases/tag/v1.1.0)
![image](https://github.com/user-attachments/assets/5f2aa001-f0f8-4b3b-b7e1-158d64d597ca)
